### PR TITLE
Support dots in Python versions in tox environment names

### DIFF
--- a/src/mddj/readers.py
+++ b/src/mddj/readers.py
@@ -52,7 +52,7 @@ def get_tox_tested_versions() -> list[str]:
     versions = set()
     for line in output.splitlines():
         for part in line.split("-"):
-            if match := re.match(r"py(\d)(\d+)", part):
+            if match := re.match(r"py(\d)\.?(\d+)", part):
                 versions.add(match.group(1) + "." + match.group(2))
     return list(versions)
 


### PR DESCRIPTION
This change is necessary to support mddj use in another project that relies on tox environments with names like `py3.13`.