### PR TITLE
Add faster path reads of static pyproject.toml values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Drop support for Python 3.8, Python 3.9
 - Update dependency bounds
+- Data is now read from `pyproject.toml` when possible, with build metadata
+  used as a fallback if that fails
 
 ## 0.0.8
 

--- a/src/mddj/_types.py
+++ b/src/mddj/_types.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import datetime
+import typing as t
+
+TomlValue: t.TypeAlias = (
+    "dict[str, TomlValue] | list[TomlValue] | str | int | datetime.datetime"
+)

--- a/src/mddj/cli/read/requires_python.py
+++ b/src/mddj/cli/read/requires_python.py
@@ -1,6 +1,9 @@
+import pathlib
+
 import click
 
 from mddj.cli.state import CommandState, common_args
+from mddj.readers import read_pyproject_toml_value
 
 
 @click.command("requires-python")
@@ -14,10 +17,14 @@ def read_requires_python(*, state: CommandState, lower_bound: bool) -> None:
     """
     Read the 'Requires-Python' data.
     """
-    data = state.read_metadata()
-    requires_python = data.get("Requires-Python")
+    # first, try reading from pyproject.toml
+    requires_python = _get_requires_python_pyproject(state.pyproject_path)
 
-    if requires_python is None or not isinstance(requires_python, str):
+    # if that fails, fallback to trying to read from build metadata
+    if requires_python is None:
+        requires_python = _get_requires_python_build(state)
+
+    if requires_python is None:
         raise RuntimeError("No Requires-Python data found")
 
     if lower_bound:
@@ -42,3 +49,20 @@ def find_lower_bound(req: str) -> str:
         raise RuntimeError("Found no lower bounds")
     else:
         return lower_bounds[0]
+
+
+def _get_requires_python_pyproject(pyproject_path: pathlib.Path) -> str | None:
+    try:
+        return str(
+            read_pyproject_toml_value(pyproject_path, "project", "requires_python")
+        )
+    except (FileNotFoundError, LookupError):
+        return None
+
+
+def _get_requires_python_build(state: CommandState) -> str | None:
+    data = state.read_metadata()
+    value = data.get("Requires-Python")
+    if value is None:
+        return None
+    return str(value)

--- a/src/mddj/cli/read/version.py
+++ b/src/mddj/cli/read/version.py
@@ -3,7 +3,6 @@ import pathlib
 import click
 
 from mddj.cli.state import CommandState, common_args
-from mddj.config import ReadVersionSetting
 from mddj.readers import read_pyproject_toml_value
 
 
@@ -11,34 +10,12 @@ from mddj.readers import read_pyproject_toml_value
 @common_args
 def read_version(*, state: CommandState) -> None:
     """Read the 'Version' of the current project."""
-    config = state.read_config()
+    # first, try reading from pyproject.toml
+    version: str | None = _get_version_pyproject(state.pyproject_path)
 
-    version: str
-    if config.read_version_setting == ReadVersionSetting.default:
-        version_pyproj = _get_version_pyproject(state.pyproject_path)
-        if version_pyproj is None:
-            version = _get_version_build(state)
-        else:
-            version = version_pyproj
-
-    elif config.read_version_setting == ReadVersionSetting.pyproject:
-        version_pyproj = _get_version_pyproject(state.pyproject_path)
-        if version_pyproj is None:
-            click.echo(
-                "No version was found in pyproject.toml:project.version.", err=True
-            )
-            click.get_current_context().exit(1)
-        else:
-            version = version_pyproj
-
-    elif config.read_version_setting == ReadVersionSetting.build:
+    # if that fails, fallback to trying to read from build metadata
+    if version is None:
         version = _get_version_build(state)
-
-    else:
-        raise NotImplementedError(
-            "'mddj read version' is missing support for "
-            f"read_version={config.read_version_setting!r}"
-        )
 
     click.echo(version)
 

--- a/src/mddj/cli/read/version.py
+++ b/src/mddj/cli/read/version.py
@@ -1,11 +1,33 @@
 import click
 
 from mddj.cli.state import CommandState, common_args
+from mddj.config import ReadVersionSetting
+from mddj.readers import read_pyproject_toml_value
 
 
 @click.command("version")
 @common_args
 def read_version(*, state: CommandState) -> None:
     """Read the 'Version' of the current project."""
-    data = state.read_metadata()
-    click.echo(data.get("Version"))
+    config = state.read_config()
+
+    if config.read_version_setting == ReadVersionSetting.pyproject:
+        try:
+            version: str = str(
+                read_pyproject_toml_value(state.pyproject_path, "project", "version")
+            )
+        except LookupError:
+            click.echo(
+                "No version was found in pyproject.toml:project.version.", err=True
+            )
+            click.get_current_context().exit(1)
+    elif config.read_version_setting == ReadVersionSetting.build:
+        data = state.read_metadata()
+        version = data.get("Version")
+    else:
+        raise NotImplementedError(
+            "'mddj read version' is missing support for "
+            f"read_version={config.read_version_setting!r}"
+        )
+
+    click.echo(version)

--- a/src/mddj/cli/read/version.py
+++ b/src/mddj/cli/read/version.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import click
 
 from mddj.cli.state import CommandState, common_args
@@ -11,19 +13,27 @@ def read_version(*, state: CommandState) -> None:
     """Read the 'Version' of the current project."""
     config = state.read_config()
 
-    if config.read_version_setting == ReadVersionSetting.pyproject:
-        try:
-            version: str = str(
-                read_pyproject_toml_value(state.pyproject_path, "project", "version")
-            )
-        except LookupError:
+    version: str
+    if config.read_version_setting == ReadVersionSetting.default:
+        version_pyproj = _get_version_pyproject(state.pyproject_path)
+        if version_pyproj is None:
+            version = _get_version_build(state)
+        else:
+            version = version_pyproj
+
+    elif config.read_version_setting == ReadVersionSetting.pyproject:
+        version_pyproj = _get_version_pyproject(state.pyproject_path)
+        if version_pyproj is None:
             click.echo(
                 "No version was found in pyproject.toml:project.version.", err=True
             )
             click.get_current_context().exit(1)
+        else:
+            version = version_pyproj
+
     elif config.read_version_setting == ReadVersionSetting.build:
-        data = state.read_metadata()
-        version = data.get("Version")
+        version = _get_version_build(state)
+
     else:
         raise NotImplementedError(
             "'mddj read version' is missing support for "
@@ -31,3 +41,15 @@ def read_version(*, state: CommandState) -> None:
         )
 
     click.echo(version)
+
+
+def _get_version_pyproject(pyproject_path: pathlib.Path) -> str | None:
+    try:
+        return str(read_pyproject_toml_value(pyproject_path, "project", "version"))
+    except (FileNotFoundError, LookupError):
+        return None
+
+
+def _get_version_build(state: CommandState) -> str:
+    data = state.read_metadata()
+    return str(data.get("Version"))

--- a/src/mddj/cli/state.py
+++ b/src/mddj/cli/state.py
@@ -19,6 +19,10 @@ class CommandState:
         self.source_dir = pathlib.Path.cwd()
 
     @functools.cached_property
+    def pyproject_path(self) -> pathlib.Path:
+        return self.source_dir / "pyproject.toml"
+
+    @functools.cached_property
     def isolated_builds(self) -> bool:
         if (var := os.environ.get("MDDJ_ISOLATED_BUILDS")) is not None:
             return not (var.lower() in ("0", "false"))
@@ -39,7 +43,7 @@ class CommandState:
         )
 
     def read_config(self) -> ConfigData:
-        return read_config(self.source_dir / "pyproject.toml")
+        return read_config(self.pyproject_path)
 
 
 def common_args(cmd: F) -> F:

--- a/src/mddj/config.py
+++ b/src/mddj/config.py
@@ -25,6 +25,9 @@ class WriteVersionAssignConfig(WriteVersionConfig):
 
 
 class ReadVersionSetting(enum.Enum):
+    # the default behavior is to first try to read pyproject.toml
+    # and fallback to getting build metadata if that doesn't work
+    default = enum.auto()
     pyproject = enum.auto()
     build = enum.auto()
 
@@ -71,7 +74,9 @@ class ConfigData:
 
     @functools.cached_property
     def read_version_setting(self) -> ReadVersionSetting:
-        if self.read_version == "pyproject.toml":
+        if self.read_version == "default":
+            return ReadVersionSetting.default
+        elif self.read_version == "pyproject.toml":
             return ReadVersionSetting.pyproject
         elif self.read_version == "build":
             return ReadVersionSetting.build
@@ -82,7 +87,7 @@ class ConfigData:
 def _default_config() -> ConfigData:
     return ConfigData(
         write_version="assign: pyproject.toml: version",
-        read_version="pyproject.toml",
+        read_version="default",
     )
 
 

--- a/src/mddj/config.py
+++ b/src/mddj/config.py
@@ -1,5 +1,4 @@
 import dataclasses
-import enum
 import functools
 import pathlib
 import sys
@@ -24,18 +23,9 @@ class WriteVersionAssignConfig(WriteVersionConfig):
     key: str
 
 
-class ReadVersionSetting(enum.Enum):
-    # the default behavior is to first try to read pyproject.toml
-    # and fallback to getting build metadata if that doesn't work
-    default = enum.auto()
-    pyproject = enum.auto()
-    build = enum.auto()
-
-
 @dataclasses.dataclass
 class ConfigData:
     write_version: str
-    read_version: str
 
     @functools.cached_property
     def write_version_config(self) -> WriteVersionConfig:
@@ -72,22 +62,10 @@ class ConfigData:
                 f"Unimplemented write_version_mode: {write_version_mode}"
             )
 
-    @functools.cached_property
-    def read_version_setting(self) -> ReadVersionSetting:
-        if self.read_version == "default":
-            return ReadVersionSetting.default
-        elif self.read_version == "pyproject.toml":
-            return ReadVersionSetting.pyproject
-        elif self.read_version == "build":
-            return ReadVersionSetting.build
-        else:
-            raise ValueError("read_version must be one of ['pyproject.toml', 'build'].")
-
 
 def _default_config() -> ConfigData:
     return ConfigData(
         write_version="assign: pyproject.toml: version",
-        read_version="default",
     )
 
 
@@ -106,5 +84,4 @@ def read_config(pyproject_path: pathlib.Path) -> ConfigData:
 
     return ConfigData(
         write_version=mddj_data.get("write_version", default.write_version),
-        read_version=mddj_data.get("read_version", default.read_version),
     )

--- a/src/mddj/config.py
+++ b/src/mddj/config.py
@@ -1,4 +1,5 @@
 import dataclasses
+import enum
 import functools
 import pathlib
 import sys
@@ -23,9 +24,15 @@ class WriteVersionAssignConfig(WriteVersionConfig):
     key: str
 
 
+class ReadVersionSetting(enum.Enum):
+    pyproject = enum.auto()
+    build = enum.auto()
+
+
 @dataclasses.dataclass
 class ConfigData:
     write_version: str
+    read_version: str
 
     @functools.cached_property
     def write_version_config(self) -> WriteVersionConfig:
@@ -62,10 +69,20 @@ class ConfigData:
                 f"Unimplemented write_version_mode: {write_version_mode}"
             )
 
+    @functools.cached_property
+    def read_version_setting(self) -> ReadVersionSetting:
+        if self.read_version == "pyproject.toml":
+            return ReadVersionSetting.pyproject
+        elif self.read_version == "build":
+            return ReadVersionSetting.build
+        else:
+            raise ValueError("read_version must be one of ['pyproject.toml', 'build'].")
+
 
 def _default_config() -> ConfigData:
     return ConfigData(
         write_version="assign: pyproject.toml: version",
+        read_version="pyproject.toml",
     )
 
 
@@ -84,4 +101,5 @@ def read_config(pyproject_path: pathlib.Path) -> ConfigData:
 
     return ConfigData(
         write_version=mddj_data.get("write_version", default.write_version),
+        read_version=mddj_data.get("read_version", default.read_version),
     )

--- a/tests/acceptance/test_pyprojecttoml.py
+++ b/tests/acceptance/test_pyprojecttoml.py
@@ -61,3 +61,26 @@ authors = [
 ]
 """
     )
+
+
+def test_read_version_from_pyproject(tmpdir, run_line):
+    pyproject = tmpdir.join("pyproject.toml")
+
+    pyproject.write(
+        """\
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "foopkg"
+version = "8.0.7"
+authors = [
+  { name = "Foo", email = "foo@example.org" },
+]
+"""
+    )
+    tmpdir.join("foopkg.py").write("")
+
+    with tmpdir.as_cwd():
+        run_line("mddj read version", search_stdout=r"^8\.0\.7$")

--- a/tests/acceptance/test_setupcfg.py
+++ b/tests/acceptance/test_setupcfg.py
@@ -24,6 +24,26 @@ python_requires = >=3.10
         run_line("mddj read requires-python", search_stdout=r"^>=3\.10$")
 
 
+def test_read_version_from_build(tmpdir, run_line):
+    setupcfg = tmpdir.join("setup.cfg")
+
+    setupcfg.write(
+        """\
+[metadata]
+name = foopkg
+version = 1.0.0
+
+author = Foo
+author_email = foo@example.org
+"""
+    )
+    tmpdir.join("setup.py").write("from setuptools import setup; setup()\n")
+    tmpdir.join("foopkg.py").write("")
+
+    with tmpdir.as_cwd():
+        run_line("mddj read version", search_stdout=r"^1\.0\.0$")
+
+
 @pytest.mark.parametrize("quote_char", ("", '"', "'"))
 def test_update_version_assignment(tmpdir, run_line, quote_char):
     setupcfg = tmpdir.join("setup.cfg")


### PR DESCRIPTION
- Add a fast-path read of `pyproject.toml` version
- Update 'read version' to try both by default
- Remove configurable 'read version'  behavior
- Add read of Requires-Python from pyproject.toml
- Add changelog for faster read behavior
