### PR TITLE
Add a discovery phase, allowing use from subdirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Data is now read from `pyproject.toml` when possible, with build metadata
   used as a fallback if that fails
 - Support Python 3.13, Python 3.14
+- `mddj` can now be used from subdirectories of a project, and will discover
+  the project root based on some simple heuristics.
 
 ## 0.0.8
 

--- a/src/mddj/cli/state.py
+++ b/src/mddj/cli/state.py
@@ -9,6 +9,7 @@ import click
 
 from mddj._compat import metadata
 from mddj.config import ConfigData, read_config
+from mddj.discovery import discover_project_dir
 from mddj.readers import get_wheel_metadata
 
 F = t.TypeVar("F", bound=t.Callable[..., t.Any])
@@ -16,7 +17,7 @@ F = t.TypeVar("F", bound=t.Callable[..., t.Any])
 
 class CommandState:
     def __init__(self) -> None:
-        self.source_dir = pathlib.Path.cwd()
+        self.source_dir = discover_project_dir()
 
     @functools.cached_property
     def pyproject_path(self) -> pathlib.Path:

--- a/src/mddj/discovery.py
+++ b/src/mddj/discovery.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pathlib
+import typing as t
+
+
+class DiscoveryError(RuntimeError):
+    pass
+
+
+def discover_project_dir() -> pathlib.Path:
+    for directory, dir_contents in _vcs_bounded_ancestors_with_contents():
+        # Rule 1: the first ancestor dir with a `pyproject.toml`
+        if "pyproject.toml" in dir_contents:
+            return directory
+
+        # Rule 2: a `setup.cfg`
+        if "setup.cfg" in dir_contents:
+            return directory
+
+        # Rule 3: `setup.py` in a directory without an `__init__.py`
+        if "setup.py" in dir_contents and "__init__.py" not in dir_contents:
+            return directory
+
+        # Rule 4: a `tox.ini` file is present, meaning we can read tox data
+        #         (maybe there is no python package but there is tox config)
+        if "tox.ini" in dir_contents:
+            return directory
+
+    # Rule 5: the root has a `setup.py`; that will be our final guess
+    if "setup.py" in dir_contents:
+        return directory
+
+    raise DiscoveryError(
+        "mddj could not find the project root. "
+        "Ensure you are running from a subdirectory of a Python package source dir."
+    )
+
+
+def _vcs_bounded_ancestors_with_contents() -> t.Iterator[tuple[pathlib.Path, set[str]]]:
+    for d in _ancestors():
+        dir_contents = {p.name for p in d.iterdir()}
+        if dir_contents.intersection((".git", ".hg", ".svn")):
+            yield d, dir_contents
+            return
+        yield d, dir_contents
+
+
+def _ancestors() -> t.Iterator[pathlib.Path]:
+    cwd = pathlib.Path.cwd()
+    yield cwd
+    yield from cwd.parents

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -1,0 +1,49 @@
+import pytest
+
+from mddj.discovery import discover_project_dir
+
+
+@pytest.mark.parametrize(
+    "indicator_file", ("pyproject.toml", "setup.cfg", "setup.py", "tox.ini")
+)
+def test_can_discover_unambiguous_project_dir(monkeypatch, tmpdir, indicator_file):
+    tmpdir.join(indicator_file).write("")
+
+    working_dir = tmpdir.join("subdir")
+    working_dir.mkdir()
+    monkeypatch.chdir(working_dir)
+
+    assert str(discover_project_dir()) == str(tmpdir)
+
+
+def test_discovery_skips_setup_py_dir_with_init_py(monkeypatch, tmpdir):
+    tmpdir.join("pyproject.toml").write("")
+
+    module_dir = tmpdir.join("subdir1")
+    module_dir.mkdir()
+
+    module_dir.join("setup.py").write("")
+    module_dir.join("__init__.py").write("")
+
+    monkeypatch.chdir(module_dir)
+
+    assert str(discover_project_dir()) == str(tmpdir)
+
+    # removing the __init__.py changes discovery
+    module_dir.join("__init__.py").remove()
+    assert str(discover_project_dir()) == str(module_dir)
+
+
+def test_discovery_selects_setup_py_at_repo_root_as_final_guess(monkeypatch, tmpdir):
+    # "repo root"
+    tmpdir.join("setup.py").write("")
+    tmpdir.join(".git").mkdir()
+    # but it contains an '__init__.py', so normally it would not be considered
+    tmpdir.join("__init__.py").write("")
+
+    subdir = tmpdir.join("subdir1")
+    subdir.mkdir()
+
+    monkeypatch.chdir(subdir)
+
+    assert str(discover_project_dir()) == str(tmpdir)


### PR DESCRIPTION
If `pyproject.toml` is present, but `mddj` is run from a subdir, e.g.,
`src/$pkg/`, then the commands will fail. This usage restriction can
be lifted by finding the project root, for which a relatively simple
heuristic is defined.
