### PR TITLE
Add support for reading 'maintainers'

### DIFF
--- a/src/mddj/_cli/read/__init__.py
+++ b/src/mddj/_cli/read/__init__.py
@@ -9,6 +9,7 @@ from .description import read_description
 from .import_names import read_import_names
 from .import_namespaces import read_import_namespaces
 from .keywords import read_keywords
+from .maintainers import read_maintainers
 from .name import read_name
 from .optional_dependencies import read_optional_dependencies
 from .requires_python import read_requires_python
@@ -29,6 +30,7 @@ read.add_command(read_description)
 read.add_command(read_import_names)
 read.add_command(read_import_namespaces)
 read.add_command(read_keywords)
+read.add_command(read_maintainers)
 read.add_command(read_name)
 read.add_command(read_optional_dependencies)
 read.add_command(read_requires_python)

--- a/src/mddj/_cli/read/maintainers.py
+++ b/src/mddj/_cli/read/maintainers.py
@@ -1,0 +1,40 @@
+import typing as t
+
+import click
+
+from mddj._cli.state import CommandState, common_args
+
+
+@click.command("maintainers")
+@common_args
+@click.option(
+    "--only",
+    type=click.Choice(("name", "email")),
+    help="Only show one field from 'maintainers' data.",
+)
+def read_maintainers(
+    *, only: t.Literal["name", "email"] | None, state: CommandState
+) -> None:
+    """
+    Read the "maintainers" of the current project.
+
+    Note that when dynamic maintainer metadata is encountered, it is not always possible
+    to perfectly reconstruct the inputs.
+    """
+    maintainers = state.dj.read.maintainers()
+
+    for maintainer_item in maintainers:
+        if only is not None and only not in maintainer_item:
+            continue
+
+        if only == "name":
+            click.echo(maintainer_item["name"])
+        elif only == "email":
+            click.echo(maintainer_item["email"])
+        else:
+            if {"name", "email"} <= maintainer_item.keys():
+                click.echo(f"{maintainer_item['name']} <{maintainer_item['email']}>")
+            elif "name" in maintainer_item:
+                click.echo(maintainer_item["name"])
+            else:
+                click.echo(f"<{maintainer_item['email']}>")

--- a/src/mddj/api/reader/__init__.py
+++ b/src/mddj/api/reader/__init__.py
@@ -121,6 +121,13 @@ class Reader:
         return value
 
     @_cached_methods.cached_method
+    def maintainers(self) -> tuple[types.MappingProxyType[str, str], ...]:
+        value = self.static.maintainers()
+        if value is None:
+            value = self.dynamic.maintainers()
+        return value
+
+    @_cached_methods.cached_method
     def optional_dependencies(
         self, *, exact_wheel_metadata: bool = False
     ) -> types.MappingProxyType[str, tuple[str, ...]]:

--- a/src/mddj/api/reader/dynamic_package_reader.py
+++ b/src/mddj/api/reader/dynamic_package_reader.py
@@ -63,6 +63,10 @@ class DynamicPackageReader:
         return self._read_string_array("Keywords", mode="commasep")
 
     @_cached_methods.cached_method
+    def maintainers(self) -> tuple[types.MappingProxyType[str, str], ...]:
+        return self._read_contact_info("Maintainer", "Maintainer-email")
+
+    @_cached_methods.cached_method
     def optional_dependencies(
         self, *, exact_wheel_metadata: bool = False
     ) -> types.MappingProxyType[str, tuple[str, ...]]:

--- a/src/mddj/api/reader/static_pyproject_reader.py
+++ b/src/mddj/api/reader/static_pyproject_reader.py
@@ -62,6 +62,10 @@ class StaticPyprojectReader:
         return self._read_string_array("keywords")
 
     @_cached_methods.cached_method
+    def maintainers(self, /) -> tuple[types.MappingProxyType[str, str], ...] | None:
+        return self._read_contact_info("maintainers")
+
+    @_cached_methods.cached_method
     def optional_dependencies(
         self,
     ) -> types.MappingProxyType[str, tuple[str, ...]] | None:

--- a/tests/acceptance/cli/read/test_read_maintainers.py
+++ b/tests/acceptance/cli/read/test_read_maintainers.py
@@ -1,0 +1,81 @@
+import re
+from textwrap import dedent as d
+
+import pytest
+
+
+@pytest.mark.parametrize("onlyopt", (None, "name", "email"))
+def test_read_maintainers_from_pyproject(chdir, tmp_path, run_line, onlyopt):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        d(
+            """\
+            [build-system]
+            requires = ["setuptools"]
+            build-backend = "setuptools.build_meta"
+
+            [project]
+            name = "foopkg"
+            version = "8.0.7"
+            maintainers = [
+              { name = "Foo", email = "foo@example.org" },
+            ]
+            """
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "foopkg.py").touch()
+
+    cmd = "mddj read maintainers"
+    expect_out = "Foo <foo@example.org>"
+    if onlyopt:
+        cmd = f"{cmd} --only {onlyopt}"
+        if onlyopt == "name":
+            expect_out = "Foo"
+        else:
+            expect_out = "foo@example.org"
+
+    expect_out = "^" + re.escape(expect_out) + "$"
+
+    with chdir(tmp_path):
+        run_line(cmd, search_stdout=expect_out)
+
+
+@pytest.mark.parametrize("onlyopt", (None, "name", "email"))
+def test_read_maintainers_from_build(chdir, tmp_path, run_line, onlyopt):
+    setupcfg = tmp_path / "setup.cfg"
+
+    setupcfg.write_text(
+        d(
+            """\
+            [metadata]
+            name = foopkg
+            version = 1.0.0
+
+            maintainer = Foo
+            maintainer_email = foo@example.org
+            """
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "setup.py").write_text(
+        "from setuptools import setup; setup()\n", encoding="utf-8"
+    )
+    (tmp_path / "foopkg.py").touch()
+
+    cmd = "mddj read maintainers"
+    if onlyopt:
+        cmd = f"{cmd} --only {onlyopt}"
+
+    # test that the expected outputs appear separately in the "both" case (any order)
+    # because setuptools can't know to combine `maintainer` and `maintainer_email` (and
+    # therefore will write them out separately)
+    if onlyopt == "name":
+        expect_out = ["^Foo$"]
+    elif onlyopt == "email":
+        expect_out = [r"^foo@example\.org$"]
+    else:
+        expect_out = ["^Foo$", r"^<foo@example\.org>$"]
+
+    with chdir(tmp_path):
+        run_line(cmd, search_stdout=expect_out)


### PR DESCRIPTION
This is an exact mirror image of support for 'authors', down to the
tests.
