### PR TITLE
Support reading ReadTheDocs configuration

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -12,6 +12,9 @@ Unreleased
   ``python_full_version()``, ``python_version()``, ``sys_platform()``
 - Add a new CLI subcommand, ``mddj read sys`` which provides access to each of
   these metadata items.
+- Add a new ``DJ.read.readthedocs`` API for reading data from a ``.readthedocs.yaml`` config.
+  Currently supports ``python_version()`` for getting the version declared.
+- Add a new CLI command, ``mddj read readthedocs project-version``
 
 0.5.0
 -----

--- a/docs/api_usage.rst
+++ b/docs/api_usage.rst
@@ -80,6 +80,9 @@ Readers
 .. autoclass:: mddj.api.reader.tox_reader.ToxReaderError
     :members:
 
+.. autoclass:: mddj.api.reader.readthedocs_reader.ReadthedocsReader
+    :members:
+
 Writers
 ^^^^^^^
 

--- a/docs/api_usage.rst
+++ b/docs/api_usage.rst
@@ -74,10 +74,10 @@ Readers
 .. autoclass:: mddj.api.reader.Reader
     :members:
 
-.. autoclass:: mddj.api.tox_reader.ToxReader
+.. autoclass:: mddj.api.reader.tox_reader.ToxReader
     :members:
 
-.. autoclass:: mddj.api.tox_reader.ToxReaderError
+.. autoclass:: mddj.api.reader.tox_reader.ToxReaderError
     :members:
 
 Writers

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -47,6 +47,42 @@ Or the ``version`` key in ``setup.cfg``:
     write_version = "assign: setup.cfg: version"
 
 
+``tool.mddj.readthedocs.python_version_path``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This setting controls the lookup path inside of ``.readthedocs.yaml`` or
+``.readthedocs.yml`` which will be used for the ReadTheDocs reader to find the
+python version.
+This should be a path in dotted notation, for example, ``"build.commands"``.
+
+Depending on how the reader is configured (see ``python_version_extraction``
+below), the path should be either to the version itself, or to a command  or
+commands which can be further parsed.
+
+Defaults to ``"build.tools.python"``.
+
+
+``tool.mddj.readthedocs.python_version_extraction``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The method which should be used to interpret the ``python_version_path``.
+
+``"verbatim"``, the default, means that the value found at the version path is
+the Python version.
+
+``"parse_uv_tool_install"`` means that the path is to a command or list of
+commands, and the data should be parsed for an invocation of
+``uv tool install ... --python X.Y``.
+
+For example, this can be combined with a parse path as follows:
+
+.. code-block:: toml
+
+    [tool.mddj.readthedocs]
+    python_version_path = "build.commands"
+    python_version_extraction = "parse_uv_tool_install"
+
+
 Environment Variables
 ---------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
   # will need it, so including it makes a wider range of usages work smoothly
   "wheel",
   "packaging",
+  "ryaml>=0.5.1",
   "build>=1.5.0",
   "pyproject_hooks>=1.2.0",
   "click>=8.3.3",
@@ -57,6 +58,11 @@ mddj = "mddj._cli:main"
 [tool.flit.sdist]
 include = ["changelog.rst", "tests/**/*.py", "tox.ini", ".flake8", "justfile"]
 exclude = [".*", "src/**/.*"]
+
+
+[tool.mddj.readthedocs]
+python_version_path = "build.commands"
+python_version_extraction = "parse_uv_tool_install"
 
 
 [tool.check-sdist]

--- a/src/mddj/_cli/read/__init__.py
+++ b/src/mddj/_cli/read/__init__.py
@@ -12,6 +12,7 @@ from .keywords import read_keywords
 from .maintainers import read_maintainers
 from .name import read_name
 from .optional_dependencies import read_optional_dependencies
+from .readthedocs import read_readthedocs
 from .requires_python import read_requires_python
 from .sys import read_sys
 from .tox import read_tox
@@ -37,5 +38,6 @@ read.add_command(read_optional_dependencies)
 read.add_command(read_requires_python)
 read.add_command(read_version)
 
+read.add_command(read_readthedocs)
 read.add_command(read_sys)
 read.add_command(read_tox)

--- a/src/mddj/_cli/read/readthedocs/__init__.py
+++ b/src/mddj/_cli/read/readthedocs/__init__.py
@@ -1,0 +1,24 @@
+import click
+
+from mddj._cli.state import CommandState, common_args
+
+
+@click.group("readthedocs")
+@common_args
+def read_readthedocs(*, state: CommandState) -> None:
+    """
+    Read information from ReadTheDocs configuration.
+    """
+
+
+@read_readthedocs.command("python-version")
+@common_args
+def python_version(*, state: CommandState) -> None:
+    """
+    Extract a Python version number from ReadTheDocs configuration.
+
+    By default, this attempts to read from 'build.tools.python'.
+    The lookup behavior can be configured in `[tool.mddj.readthedocs]`.
+    """
+    value = state.dj.read.readthedocs.python_version()
+    click.echo(value)

--- a/src/mddj/_internal/_cached_methods.py
+++ b/src/mddj/_internal/_cached_methods.py
@@ -1,3 +1,4 @@
+import functools
 import typing as t
 
 P = t.ParamSpec("P")
@@ -33,6 +34,7 @@ def cached_method(
     The object being decorated must have a ``_method_cache`` attribute.
     """
 
+    @functools.wraps(method)
     def wrapper(instance: X, /, *args: t.Any, **kwargs: t.Any) -> R:
         cache = instance._method_cache
         key = _make_key(method.__name__, args, kwargs)

--- a/src/mddj/api/config.py
+++ b/src/mddj/api/config.py
@@ -170,3 +170,64 @@ class WriteVersionAssignSettings:
             key = config_str.strip()
 
         return cls(file_path=pathlib.Path(file_path), key=key)
+
+
+@dataclasses.dataclass
+class ReadthedocsConfig:
+    project_directory: pathlib.Path
+    python_version_path: str = "build.tools.python"
+    python_version_extraction: t.Literal["verbatim", "parse_uv_tool_install"] = (
+        "verbatim"
+    )
+
+    @classmethod
+    def load_from_toml(
+        cls,
+        *,
+        project_directory: pathlib.Path,
+        pyproject_path: pathlib.Path,
+        document_cache: _cached_toml.TomlDocumentCache,
+    ) -> Self:
+        import tomlkit
+
+        if not pyproject_path.exists():
+            return cls(project_directory)
+
+        data = document_cache.load(pyproject_path)
+
+        try:
+            tool_table = data["tool"]
+            if not isinstance(tool_table, tomlkit.items.Table):
+                raise KeyError("'tool' was not a table")
+            mddj_data = tool_table["mddj"]
+            if not isinstance(mddj_data, tomlkit.items.Table):
+                raise KeyError("'tool.mddj' was not a table")
+
+            readthedocs_conf = mddj_data["readthedocs"]
+            if not isinstance(readthedocs_conf, tomlkit.items.Table):
+                raise KeyError("'tool.mddj.readthedocs' was not a table")
+
+            py_ver_path = "build.tools.python"
+            if "python_version_path" in readthedocs_conf:
+                py_ver_path = readthedocs_conf["python_version_path"]
+                if not isinstance(py_ver_path, str):
+                    raise ValueError(
+                        "'tool.mddj.readthedocs.python_version_path' must be a string"
+                    )
+
+            py_ver_extraction = "verbatim"
+            if "python_version_extraction" in readthedocs_conf:
+                py_ver_extraction = readthedocs_conf["python_version_extraction"]
+                if py_ver_extraction not in ("verbatim", "parse_uv_tool_install"):
+                    raise ValueError(
+                        "'tool.mddj.readthedocs.python_version_extraction' must "
+                        "be either 'verbatim' or 'parse_uv_tool_install'."
+                    )
+        except KeyError:
+            return cls(project_directory)
+
+        return cls(
+            project_directory,
+            python_version_path=py_ver_path,
+            python_version_extraction=py_ver_extraction,
+        )

--- a/src/mddj/api/config.py
+++ b/src/mddj/api/config.py
@@ -172,13 +172,14 @@ class WriteVersionAssignSettings:
         return cls(file_path=pathlib.Path(file_path), key=key)
 
 
+PythonVersionExtraction: t.TypeAlias = t.Literal["verbatim", "parse_uv_tool_install"]
+
+
 @dataclasses.dataclass
 class ReadthedocsConfig:
     project_directory: pathlib.Path
     python_version_path: str = "build.tools.python"
-    python_version_extraction: t.Literal["verbatim", "parse_uv_tool_install"] = (
-        "verbatim"
-    )
+    python_version_extraction: PythonVersionExtraction = "verbatim"
 
     @classmethod
     def load_from_toml(
@@ -215,7 +216,7 @@ class ReadthedocsConfig:
                         "'tool.mddj.readthedocs.python_version_path' must be a string"
                     )
 
-            py_ver_extraction = "verbatim"
+            py_ver_extraction: PythonVersionExtraction = "verbatim"
             if "python_version_extraction" in readthedocs_conf:
                 py_ver_extraction = readthedocs_conf["python_version_extraction"]
                 if py_ver_extraction not in ("verbatim", "parse_uv_tool_install"):

--- a/src/mddj/api/reader/__init__.py
+++ b/src/mddj/api/reader/__init__.py
@@ -6,8 +6,9 @@ import types
 import typing as t
 
 from ..._internal import _cached_methods, _cached_toml
-from ..config import ReaderConfig
+from ..config import ReaderConfig, ReadthedocsConfig
 from .dynamic_package_reader import DynamicPackageReader
+from .readthedocs_reader import ReadthedocsReader
 from .static_pyproject_reader import StaticPyprojectReader
 from .system_info_reader import SystemInfoReader
 from .tox_reader import ToxReader
@@ -53,6 +54,13 @@ class Reader:
 
         self.tox = ToxReader()
         self.sys = SystemInfoReader()
+        self.readthedocs = ReadthedocsReader(
+            ReadthedocsConfig.load_from_toml(
+                project_directory=self.config.project_directory,
+                pyproject_path=config.pyproject_path,
+                document_cache=document_cache,
+            )
+        )
         self.static = StaticPyprojectReader(
             self.config.pyproject_path,
             document_cache=document_cache or _cached_toml.TomlDocumentCache(),

--- a/src/mddj/api/reader/__init__.py
+++ b/src/mddj/api/reader/__init__.py
@@ -50,6 +50,8 @@ class Reader:
         config: ReaderConfig,
         document_cache: _cached_toml.TomlDocumentCache | None = None,
     ) -> None:
+        document_cache = document_cache or _cached_toml.TomlDocumentCache()
+
         self.config = config
 
         self.tox = ToxReader()
@@ -62,8 +64,7 @@ class Reader:
             )
         )
         self.static = StaticPyprojectReader(
-            self.config.pyproject_path,
-            document_cache=document_cache or _cached_toml.TomlDocumentCache(),
+            self.config.pyproject_path, document_cache=document_cache
         )
         self.dynamic = DynamicPackageReader(
             self.config.project_directory,

--- a/src/mddj/api/reader/readthedocs_reader.py
+++ b/src/mddj/api/reader/readthedocs_reader.py
@@ -4,7 +4,8 @@ import pathlib
 import shlex
 import typing as t
 
-import ryaml
+# for some reason, mypy flags 'loads' as not explicitly exported
+from ryaml import loads as _ryaml_loads  # type: ignore[attr-defined]
 
 from ..._internal import _cached_methods, _toml_path
 from ..config import ReadthedocsConfig
@@ -49,7 +50,7 @@ class ReadthedocsReader:
     def _load_data(self) -> dict[str, t.Any]:
         content = self._config_path.read_text()
 
-        data = ryaml.loads(content)
+        data = _ryaml_loads(content)
         if not isinstance(data, dict):
             raise ValueError("Expected readthedocs config to parse as a dict.")
         return data
@@ -67,7 +68,9 @@ class ReadthedocsReader:
         config_body = self._load_data()
         value = config_body
         for part in self._parsed_version_path:
-            value = value[part]
+            # mypy flags that parts are 'int|str', but the config_body is declared as
+            # a 'dict[str, Any]'
+            value = value[part]  # type: ignore[index]
 
         if self._config.python_version_extraction == "verbatim":
             return _verbatim_process_parsed_version(value)
@@ -113,7 +116,8 @@ def _extract_uv_tool_install_version(commands: t.Any) -> str:
     parser.add_argument("--python")
     parsed_args, _ = parser.parse_known_args(split_cmd)
 
-    if parsed_args.python:
-        return parsed_args.python
+    parsed_python_version: str | None = parsed_args.python
+    if parsed_python_version:
+        return parsed_python_version
 
     raise LookupError("'uv tool install' command did not specify '--python'")

--- a/src/mddj/api/reader/readthedocs_reader.py
+++ b/src/mddj/api/reader/readthedocs_reader.py
@@ -1,0 +1,119 @@
+import argparse
+import functools
+import pathlib
+import shlex
+import typing as t
+
+import ryaml
+
+from ..._internal import _cached_methods, _toml_path
+from ..config import ReadthedocsConfig
+
+
+class ReadthedocsConfigNotFoundError(ValueError):
+    pass
+
+
+class ReadthedocsReader:
+    """
+    A ReadthedocsReader is a data reader for ``readthedocs`` configuration.
+
+    Typically, users should simply create a DJ and then access the reader built by
+    it, as in:
+
+    .. code-block:: pycon
+
+        >>> from mddj.api import DJ
+        >>> dj = DJ()
+        >>> dj.read.readthedocs.python_version()
+        '3.11'
+    """
+
+    def __init__(self, config: ReadthedocsConfig) -> None:
+        self._config = config
+        self._method_cache: dict[t.Any, t.Any] = {}
+
+    @functools.cached_property
+    def _config_path(self) -> pathlib.Path:
+        yaml_path = self._config.project_directory / ".readthedocs.yaml"
+        if yaml_path.exists():
+            return yaml_path
+        yml_path = self._config.project_directory / ".readthedocs.yml"
+        if yml_path.exists():
+            return yml_path
+        raise ReadthedocsConfigNotFoundError(
+            "No ReadTheDocs configuration was detected."
+        )
+
+    @_cached_methods.cached_method
+    def _load_data(self) -> dict[str, t.Any]:
+        content = self._config_path.read_text()
+
+        data = ryaml.loads(content)
+        if not isinstance(data, dict):
+            raise ValueError("Expected readthedocs config to parse as a dict.")
+        return data
+
+    @functools.cached_property
+    def _parsed_version_path(self) -> list[str | int]:
+        return _toml_path.parse_toml_path(self._config.python_version_path)
+
+    @_cached_methods.cached_method
+    def python_version(self) -> str:
+        """
+        Read the Python version out of ReadTheDocs configuration, using the
+        configured read method.
+        """
+        config_body = self._load_data()
+        value = config_body
+        for part in self._parsed_version_path:
+            value = value[part]
+
+        if self._config.python_version_extraction == "verbatim":
+            return _verbatim_process_parsed_version(value)
+        elif self._config.python_version_extraction == "parse_uv_tool_install":
+            return _extract_uv_tool_install_version(value)
+        else:
+            raise NotImplementedError(
+                "configuration error: ReadthedocsReader does not support "
+                f"{self._config.python_version_extraction}"
+            )
+
+
+def _verbatim_process_parsed_version(value: t.Any) -> str:
+    # unfortunately, it could be an unquoted value, parsed as a float...
+    if not isinstance(value, (str, float)):
+        raise LookupError(
+            "verbatim lookup of the python version from readthedocs "
+            f"config got a value of an invalid type: {value!r}"
+        )
+
+    return str(value)
+
+
+def _extract_uv_tool_install_version(commands: t.Any) -> str:
+    if isinstance(commands, str):
+        commands = [commands]
+    if not isinstance(commands, list):
+        raise LookupError(
+            "'uv tool install' version parsing requires a path to install "
+            "commands, which should be a string or list of strings."
+        )
+    for cmd in commands:
+        if not isinstance(cmd, str):
+            continue
+        split_cmd = shlex.split(cmd)
+        if split_cmd[:3] != ["uv", "tool", "install"]:
+            continue
+        break
+    else:
+        raise LookupError("Did not find a 'uv tool install' command.")
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--python")
+    parsed_args, _ = parser.parse_known_args(split_cmd)
+
+    if parsed_args.python:
+        return parsed_args.python
+
+    raise LookupError("'uv tool install' command did not specify '--python'")

--- a/tests/acceptance/cli/read/test_readthedocs.py
+++ b/tests/acceptance/cli/read/test_readthedocs.py
@@ -1,0 +1,61 @@
+from textwrap import dedent as d
+
+import pytest
+
+
+@pytest.mark.parametrize("extension", ("yaml", "yml"))
+def test_read_python_version_default(chdir, tmp_path, run_line, extension):
+    (tmp_path / "pyproject.toml").touch()
+
+    rtd_yaml = tmp_path / f".readthedocs.{extension}"
+
+    rtd_yaml.write_text(
+        d(
+            """\
+            version: 2
+            build:
+              os: ubuntu-24.04
+              tools:
+                python: "3.13"
+            """
+        )
+    )
+
+    with chdir(tmp_path):
+        run_line("mddj read readthedocs python-version", search_stdout=r"^3\.13$")
+
+
+def test_read_python_version_from_uv_tool_install(chdir, tmp_path, run_line):
+    (tmp_path / "pyproject.toml").write_text(
+        d(
+            """\
+            [tool.mddj.readthedocs]
+            python_version_path = "build.commands"
+            python_version_extraction = "parse_uv_tool_install"
+            """
+        )
+    )
+
+    rtd_yaml = tmp_path / ".readthedocs.yaml"
+
+    rtd_yaml.write_text(
+        d(
+            """\
+            version: 2
+
+            build:
+              os: ubuntu-24.04
+
+              commands:
+                - asdf plugin add uv
+                - asdf install uv latest
+                - asdf global uv latest
+
+                - uv tool install tox --with tox-uv --python "3.14" --managed-python
+                - uv tool run tox run -e docs -- "${READTHEDOCS_OUTPUT}"/html
+            """
+        )
+    )
+
+    with chdir(tmp_path):
+        run_line("mddj read readthedocs python-version", search_stdout=r"^3\.14$")


### PR DESCRIPTION
This changeset introduces a `ReadthedocsReader` with one function, `python_version()` and the attendant CLI command, `mddj read readthedocs python-version`.

Because RTD config can be in a variety of formats, the *default* is to read from `build.tools.python` but we have new config keys for setting RTD to read from a `uv tool install` command.

Also:

- fixes broken doc builds (whoops!)
- introduces the use of `ryaml` as our YAML parser
